### PR TITLE
chore: copy libmlx.dylib to build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(minilibx)
 add_custom_target(build_minilibx ALL
 	COMMAND make -C ${minilibx_SOURCE_DIR} -j1
+	COMMAND cp ${minilibx_SOURCE_DIR}/libmlx.dylib ${CMAKE_BINARY_DIR}
 )
 set(MINILIBX_LIBRARY ${minilibx_SOURCE_DIR}/libmlx.dylib)
 


### PR DESCRIPTION
11 chore fix libmlxdylib directory