### PR TITLE
41 fix camera z axis bug

### DIFF
--- a/includes/error.h
+++ b/includes/error.h
@@ -6,7 +6,7 @@
 /*   By: jeongwpa <jeongwpa@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 17:41:02 by jeongwpa          #+#    #+#             */
-/*   Updated: 2024/08/23 01:03:31 by jeongwpa         ###   ########.fr       */
+/*   Updated: 2024/08/24 23:29:23 by jeongwpa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@
 # define ERROR_INVALID_FOV "FOV must be between 0 and 180"
 # define ERROR_INVALID_COLOR "Color must be between 0 and 255"
 # define ERROR_INVALID_NORMAL "Normal must be between -1 and 1"
+# define ERROR_ZERO_NORMAL "Normal cannot be zero"
 # define ERROR_INVALID_RATIO "Ratio must be between 0 and 1"
 # define ERROR_INVALID_TEXTURE_OPTION "Invalid texture option"
 # define ERROR_OPEN_XPM_FILE "Failed to open the xpm file"

--- a/srcs/parse/minirt_parse_utils2.c
+++ b/srcs/parse/minirt_parse_utils2.c
@@ -6,7 +6,7 @@
 /*   By: jeongwpa <jeongwpa@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/06 20:11:34 by jeongwpa          #+#    #+#             */
-/*   Updated: 2024/08/22 20:07:03 by jeongwpa         ###   ########.fr       */
+/*   Updated: 2024/08/24 23:29:44 by jeongwpa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,8 @@ void	must_be_valid_normal(t_vec3 normal)
 		error_exit(ERROR_INVALID_NORMAL);
 	if (normal.z < -1 || normal.z > 1)
 		error_exit(ERROR_INVALID_NORMAL);
+	if (normal.x == 0 && normal.y == 0 && normal.z == 0)
+		error_exit(ERROR_ZERO_NORMAL);
 }
 
 void	normalize_vec3(t_vec3 *vec)
@@ -44,12 +46,7 @@ void	normalize_vec3(t_vec3 *vec)
 	must_be_valid_normal(*vec);
 	magnitude = vec3_length(*vec);
 	if (magnitude == 0)
-	{
-		vec->x = 0;
-		vec->y = 0;
-		vec->z = 0;
-		return ;
-	}
+		error_exit(ERROR_ZERO_NORMAL);
 	vec->x /= magnitude;
 	vec->y /= magnitude;
 	vec->z /= magnitude;

--- a/test/normalize_vec3_test.cpp
+++ b/test/normalize_vec3_test.cpp
@@ -20,8 +20,6 @@ TEST(normalize_vec3_test, 법선_벡터가_범위를_벗어난_경우)
 TEST(normalize_vec3_test, 제로_벡터인_경우)
 {
     t_vec3 vec = {0, 0, 0};
-    normalize_vec3(&vec);
-    ASSERT_FLOAT_EQ(vec.x, 0);
-    ASSERT_FLOAT_EQ(vec.y, 0);
-    ASSERT_FLOAT_EQ(vec.z, 0);
+
+    ASSERT_THROW(normalize_vec3(&vec), std::runtime_error);
 }


### PR DESCRIPTION
## 개요
<!-- PR 내용에 대해 간략하게 작성 -->

- fix: camera z axis bug

## 작업내용 
<!-- 작업 내용을 상세하게 작성 -->

- z 축이 0인 경우 화면이 이상하게 나왔던 것은 법선 벡터의 크기가 0일 수 없기 때문.
  - must_be_valid_normal 함수에 크기가 0인경우 에러 처리 추가
  - normalize_vec3 함수에 크기가 0인 경우 에러처리 추가

## 논의사항 
<!-- 임의로 수정했거나 코드 충돌 관련 내용 작성 -->

## Issue 번호
<!-- 연관된 이슈 번호 작성 e.g. closed #42 -->

- closed #41
